### PR TITLE
feat: Throw type error for incorrect middleware options

### DIFF
--- a/src/middleware/Cli.js
+++ b/src/middleware/Cli.js
@@ -39,8 +39,14 @@ export default class Cli {
    * commander.
    * @param {!string} options.name - The name of the Cli program.
    * @param {!string} options.version - The version of the Cli program.
+   * @throw {TypeError} - 'name' and 'version' are required options for the Cli
+   * middleware!
    */
   constructor(PopApi: any, {argv, name, version}: Object): void {
+    if (!name || !version) {
+      throw new TypeError('\'name\' and \'version\' are required options for the Cli middleware!')
+    }
+
     /**
      * The command line parser to process the Cli inputs.
      * @type {Command}

--- a/src/middleware/Database.js
+++ b/src/middleware/Database.js
@@ -60,6 +60,8 @@ export default class Database {
    * connection.
    * @param {?string} [options.password] - The password for the database
    * connection.
+   * @throws {TypeError} - 'database' is a required option for the Database
+   * middleware!
    */
   constructor(PopApi: any, {
     database,
@@ -68,6 +70,10 @@ export default class Database {
     username,
     password
   }: Object): void {
+    if (!database) {
+      throw new TypeError('\'database\' is a required option for the Database middleware!')
+    }
+
     process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
     const {

--- a/src/middleware/HttpServer.js
+++ b/src/middleware/HttpServer.js
@@ -41,12 +41,18 @@ export default class HttpServer {
    * @param {!number} [options.serverPort=process.env.PORT] - The port the API
    * will run on.
    * @param {!number} [options.workers=2] - The amount of workers to fork.
+   * @throws {TypeError} - 'app' is a required option for the HttpServer
+   * middleware!
    */
   constructor(PopApi: any, {
     app,
     serverPort = process.env.PORT,
     workers = 2
   }: Object): void {
+    if (!app) {
+      throw new TypeError('\'app\' is a required option for the HttpServer middleware!')
+    }
+
     /**
      * The amount of workers on the cluster.
      * @type {number}

--- a/src/middleware/Logger.js
+++ b/src/middleware/Logger.js
@@ -61,8 +61,14 @@ export default class Logger {
    * @param {!string} options.name - The name of the log file.
    * @param {?boolean} [options.pretty] - Pretty mode for output with colors.
    * @param {?boolean} [options.quiet] - No output.
+   * @throws {TypeError} - 'name' and 'logDir' are required options for the
+   * Logger middleware!
    */
   constructor(PopApi: any, {name, logDir, pretty, quiet}: Object): void {
+    if (!name || !logDir) {
+      throw new TypeError('\'name\' and \'logDir\' are required options for the Logger middleware!')
+    }
+
     /**
      * The log levels the logger middleware will be using.
      * @type {Object}

--- a/src/middleware/Routes.js
+++ b/src/middleware/Routes.js
@@ -30,8 +30,14 @@ export default class Routes {
    * @param {!Express} options.app - The application instance to add middleware
    * and bind the routes to.
    * @param {?Array<Object>} options.controllers - The controllers to register.
+   * @throws {TypeError} - 'app' are required options for the routes
+   * middleware!
    */
   constructor(PopApi: any, {app, controllers}: Object): void {
+    if (!app) {
+      throw new TypeError('\'app\' is a required option for the Routes middleware!')
+    }
+
     this.setupRoutes(app, PopApi, controllers)
   }
 

--- a/test/middleware/Cli.spec.js
+++ b/test/middleware/Cli.spec.js
@@ -59,6 +59,16 @@ describe('Cli', () => {
       version
     })
     expect(cli).to.be.an('object')
+
+    try {
+      new Cli({}, {}) // eslint-disable-line no-new
+      expect(true).to.be.false
+    } catch (err) {
+      expect(err).to.be.an('Error')
+      expect(err.message).to.equal(
+        '\'name\' and \'version\' are required options for the Cli middleware!'
+      )
+    }
   })
 
   /** @test {Cli#constructor} */

--- a/test/middleware/Database.spec.js
+++ b/test/middleware/Database.spec.js
@@ -76,6 +76,16 @@ describe('Database', () => {
       database: name
     })
     process.env.MONGO_PORT_27017_TCP_ADDR = stub
+
+    try {
+      new Database({}, {}) // eslint-disable-line no-new
+      expect(true).to.be.false
+    } catch (err) {
+      expect(err).to.be.an('Error')
+      expect(err.message).to.equal(
+        '\'database\' is a required option for the Database middleware!'
+      )
+    }
   })
 
   /** @test {Database#constructor} */

--- a/test/middleware/HttpServer.spec.js
+++ b/test/middleware/HttpServer.spec.js
@@ -62,6 +62,16 @@ describe('HttpServer', () => {
       app,
       workers: 0
     })
+
+    try {
+      new HttpServer({}, {}) // eslint-disable-line no-new
+      expect(true).to.be.false
+    } catch (err) {
+      expect(err).to.be.an('Error')
+      expect(err.message).to.equal(
+        '\'app\' is a required option for the HttpServer middleware!'
+      )
+    }
   })
 
   /** @test {HttpServer#constructor} */

--- a/test/middleware/Logger.spec.js
+++ b/test/middleware/Logger.spec.js
@@ -61,6 +61,16 @@ describe('Logger', () => {
     })
     expect(logger).to.be.an('object')
 
+    try {
+      new Logger({}, {}) // eslint-disable-line no-new
+      expect(true).to.be.false
+    } catch (err) {
+      expect(err).to.be.an('Error')
+      expect(err.message).to.equal(
+        '\'name\' and \'logDir\' are required options for the Logger middleware!'
+      )
+    }
+
     processStub.restore()
     padStartStub.restore()
   })

--- a/test/middleware/Routes.spec.js
+++ b/test/middleware/Routes.spec.js
@@ -79,6 +79,16 @@ describe('Routes', () => {
   /** @test {Routes#constructor} */
   it('should register the routes when creating a new Routes object', () => {
     new Routes({}, { app }) // eslint-disable-line no-new
+
+    try {
+      new Routes({}, {}) // eslint-disable-line no-new
+      expect(true).to.be.false
+    } catch (err) {
+      expect(err).to.be.an('Error')
+      expect(err.message).to.equal(
+        '\'app\' is a required option for the Routes middleware!'
+      )
+    }
   })
 
   /** @test {Routes#registerControllers} */


### PR DESCRIPTION
Fixes #35

## Proposed Changes

  - Throw a `TypeError` if required options aren't given:
    - Cli: `name` or `version`
    - Database: `database`
    - HttpServer: `app`
    - Logger: `name` or `logDir`
    - Routes: `app`
