### PR TITLE
refactor: Rename import and export collection

### DIFF
--- a/src/middleware/Database.js
+++ b/src/middleware/Database.js
@@ -117,7 +117,7 @@ export default class Database {
    * @returns {Promise<string, undefined>} - The promise to export a
    * collection.
    */
-  exportCollection(
+  exportFile(
     collection: string,
     outputFile: string
   ): Promise<string | void> {
@@ -135,7 +135,7 @@ export default class Database {
    * @returns {Promise<string, undefined>} - The promise to import a
    * collection.
    */
-  importCollection(
+  importFile(
     collection: string,
     jsonFile: string
   ): Promise<string | void> {

--- a/test/middleware/Database.spec.js
+++ b/test/middleware/Database.spec.js
@@ -169,33 +169,33 @@ describe('Database', () => {
       })
   })
 
-  /** @test {Database#exportCollection} */
-  it('should export a collection', done => {
+  /** @test {Database#exportFile} */
+  it('should export a file', done => {
     const collection = 'example'
     const outputFile = join(...[
       logDir,
       `${collection}s.json`
     ])
 
-    database.exportCollection(collection, outputFile).then(res => {
+    database.exportFile(collection, outputFile).then(res => {
       expect(res).to.be.undefined
       done()
     }).catch(done)
   })
 
-  /** @test {Database#importCollection} */
-  it('should import a collection', done => {
+  /** @test {Database#importFile} */
+  it('should import a file', done => {
     const file = './examples/exampleModel1.json'
 
-    database.importCollection('example', file).then(res => {
+    database.importFile('example', file).then(res => {
       expect(res).to.be.undefined
       done()
     }).catch(done)
   })
 
-  /** @test {Database#importCollection} */
+  /** @test {Database#importFile} */
   it('should not find the file to import', done => {
-    database.importCollection('example', '/data/example.json')
+    database.importFile('example', '/data/example.json')
       .then(done)
       .catch(err => {
         expect(err).to.be.an('Error')


### PR DESCRIPTION
Fixes #24

## Proposed Changes

  - rename `importCollection` to `importFile`
  - rename `exportCollection` to `exportFile`

